### PR TITLE
Changes `main` package path from absolute to relative

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "git@github.com:NCR-Shi/pdf417.git"
   },
-  "main": "/build/index.js",
+  "main": "./build/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack"


### PR DESCRIPTION
Hello!

First off, thanks for your work on this package.

I'm having an issue with Jest not being able to find the package. Running the app normally works fine, however when running tests, I get this error:

```
src/containers/Layout/Layout.test.js
  ● Test suite failed to run

    Cannot find module 'pdf417' from 'HomePage.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:179:17)
      at Object.<anonymous> (src/containers/Home/HomePage.js:13:12)
```

Switching the `main` path in `package.json` to be relative seems to fix this issue. Thoughts?

Thanks again