### PR TITLE
fix/package-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "git@github.com:NCR-Shi/pdf417.git"
   },
-  "main": "/build/index.js",
+  "main": "build/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack"


### PR DESCRIPTION
Fix the `main` path in package.json. Using `/build/index.js` tries to import from the system wide root directory, which breaks when you try to import this from `node_modules`. Using `build/index.js` will resolve relative to the package.json file, which gives us the expected result.